### PR TITLE
Try using 0.0.0.0 as hostname for otlp receiver, instead of "otelcol"

### DIFF
--- a/fly/otel-collector/otel_config.yml
+++ b/fly/otel-collector/otel_config.yml
@@ -17,7 +17,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: otelcol:4317 # here we tell OpenTelemetryCollector to listen for metrics submissions from our main app
+        endpoint: 0.0.0.0:4317 # here we tell OpenTelemetryCollector to listen for metrics submissions from our main app
 
 exporters:
   prometheusremotewrite:


### PR DESCRIPTION
As an alternative, if this fails, you can try `fly-local-6pn:4317`, but I think then we need to force the otel collector to specifically bind to that address (docs [here](https://fly.io/docs/getting-started/app-services/#private-services-on-6pn-direct-wireguard-connections))

It might also be good to make sure that the change in the PR does not publicly expose `:4137` outside of the container.

I'm flying by the seat of my pants with fly networking here, going off of this guide: https://fly.io/docs/getting-started/app-services/#tl-dr
