### PR TITLE
Use ContractScan for multichain contract deployment links

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,15 +8,15 @@ The below table shows the versions of the contract and versions of the factory a
 
 | Version | Address                                                                                                                |
 | ------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 0.1.0   | [0x0000000000756D3E6464f5efe7e413a0Af1C7474](https://blockscan.com/address/0x0000000000756D3E6464f5efe7e413a0Af1C7474) |
-| 0.2.0   | [0x00000000001269b052C004FFB71B47AB22C898B0](https://blockscan.com/address/0x00000000001269b052C004FFB71B47AB22C898B0) |
+| 0.1.0   | [0x0000000000756D3E6464f5efe7e413a0Af1C7474](https://contractscan.xyz/contract/0x0000000000756D3E6464f5efe7e413a0Af1C7474) |
+| 0.2.0   | [0x00000000001269b052C004FFB71B47AB22C898B0](https://contractscan.xyz/contract/0x00000000001269b052C004FFB71B47AB22C898B0) |
 
 ### Implementation
 
 | Version | Address                                                                                                                |
 | ------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 0.1.0   | [0x8FB3cFDf2082C2be7D3205D361067748Ea1aBF63](https://blockscan.com/address/0x8FB3cFDf2082C2be7D3205D361067748Ea1aBF63) |
-| 0.2.0   | [0x040D53C5DDE1762F7cac48d5467E88236d4873d7](https://blockscan.com/address/0x040D53C5DDE1762F7cac48d5467E88236d4873d7) |
+| 0.1.0   | [0x8FB3cFDf2082C2be7D3205D361067748Ea1aBF63](https://contractscan.xyz/contract/0x8FB3cFDf2082C2be7D3205D361067748Ea1aBF63) |
+| 0.2.0   | [0x040D53C5DDE1762F7cac48d5467E88236d4873d7](https://contractscan.xyz/contract/0x040D53C5DDE1762F7cac48d5467E88236d4873d7) |
 
 ## Deployments
 


### PR DESCRIPTION
Replaces Blockscan with ContractScan. The latter only highlights the networks where the code is actually deployed (vs those that have no code but some state e.g. balance), supports over 100 networks (vs 50ish), and is open-source.

> Disclaimer: author of ContractScan